### PR TITLE
Fix paginator

### DIFF
--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -59,13 +59,11 @@ class ShopifyStream(GraphQLStream):
             location="header",
         )
 
-    @property
     def get_new_paginator(self):
-        if not self.replication_key or self.config.get("bulk"):
-            paginator = SinglePagePaginator
+        if self.config.get("bulk"):
+            return SinglePagePaginator()
         else:
-            paginator = ShopifyPaginator
-        return paginator
+            return ShopifyPaginator(self.logger)
 
     @property
     def http_headers(self) -> dict:

--- a/tap_shopify/client_gql.py
+++ b/tap_shopify/client_gql.py
@@ -64,7 +64,7 @@ class shopifyGqlStream(ShopifyStream):
             "variables": params,
         }
         self.saved_context = context
-        self.logger.debug(f"Attempting query:\n{query}")
+        self.logger.debug(f"Attempting query:\n{query}, with params {params}, with context {context}, and next_page_token {next_page_token}")
         return request_data
     
     def ignore_path(self, path):

--- a/tap_shopify/paginator.py
+++ b/tap_shopify/paginator.py
@@ -1,5 +1,6 @@
 import math
 from functools import cached_property
+import sys
 from time import sleep
 
 import requests
@@ -11,45 +12,57 @@ from singer_sdk.pagination import BaseAPIPaginator
 class ShopifyPaginator(BaseAPIPaginator):
     """shopify paginator class."""
 
-    query_cost = None
-    available_points = None
-    restore_rate = None
-    max_points = None
-
-    def __init__(self) -> None:
+    def __init__(self, logger, *args, **kwargs) -> None:
         """Create a new paginator.
 
         Args:
             start_value: Initial value.
         """
-        self._value = None
+        self._logger = logger
         self._page_count = 0
+        self._page_size = 0
         self._finished = False
-        self._last_seen_record: dict | None = None
+        self._query_cost = None
+        self._available_points = None
+        self._restore_rate = None
+        self._max_points = 10000
+        self._single_query_max_cost_limt = 1000
+        super().__init__(None, *args, **kwargs)
 
     @property
     def page_size(self) -> int:
         """Return the page size for the stream."""
-        if not self.available_points:
+        if not self._available_points or not self._query_cost:
+            self._page_size = 1
             return 1
-        pages = self.available_points / self.query_cost
-        if pages < 5:
-            points_to_restore = self.max_points - self.available_points
-            sleep(points_to_restore // self.restore_rate - 1)
-            pages = (self.max_points - self.restore_rate) / self.query_cost
-            pages = pages - 1
-        elif self.query_cost and pages > 5:
-            if self.query_cost * pages >= 1000:
-                pages = math.floor(1000 / self.query_cost)
-        return 250 if pages > 250 else pages
+
+        # We want to leave at least 1/4 of the max points, or 2 single queries worth of points.
+        # 1/4 points so we leave room for others, it's really all about the restore rate for big jobs.
+        # 2 single queries worth of points so we can send spend at least 1 in the next cycle
+        min_leftover_points = max(self._max_points // 4, (2 * self._single_query_max_cost_limt))
+        if self._available_points < min_leftover_points:
+            # Wait until we hit min.
+            sleep_time = math.ceil((min_leftover_points - self._available_points) / self._restore_rate)
+            self._logger.info(f"Sleeping for {sleep_time} seconds to restore points. {self._available_points} points left, restoring to {min_leftover_points}")
+            sleep(sleep_time)
+
+        # Send one max query.
+        est_per_query_cost = self._query_cost / self._page_size
+        new_page_size = self._single_query_max_cost_limt / est_per_query_cost
+        self._page_size = 250 if new_page_size > 250 else int(new_page_size)
+        self._logger.debug(f"Next page size {self._page_size}")
+        return self._page_size
 
     def query_name(self, response_json) -> str:
         """Set or return the GraphQL query name."""
         return list(response_json.get("data"))[0]
 
+    # Use get_next to handle finished.
+    def has_more(self, _: requests.Response) -> bool:
+        return True
+
     def get_next(self, response: requests.Response):
         """Get the next pagination value."""
-
         response_json = response.json()
 
         # Request failed. No next page.
@@ -60,11 +73,12 @@ class ShopifyPaginator(BaseAPIPaginator):
         query_name = self.query_name(response_json)
 
         cost = response_json["extensions"].get("cost")
+        self._logger.debug(f"Query cost profile {cost}")
 
-        self.query_cost = cost.get("requestedQueryCost")
-        self.available_points = cost["throttleStatus"].get("currentlyAvailable")
-        self.restore_rate = cost["throttleStatus"].get("restoreRate")
-        self.max_points = cost["throttleStatus"].get("maximumAvailable")
+        self._query_cost = cost.get("requestedQueryCost")
+        self._available_points = cost["throttleStatus"].get("currentlyAvailable")
+        self._restore_rate = cost["throttleStatus"].get("restoreRate")
+        self._max_points = cost["throttleStatus"].get("maximumAvailable")
 
         has_next_json_path = f"$.data.{query_name}.pageInfo.hasNextPage"
         has_next = next(extract_jsonpath(has_next_json_path, response_json))


### PR DESCRIPTION
- Don't use globals, they'll stop on eachother in the recursive case (error handling)
- New fallback logic
  - Leave at least 1/4 of max points.
  - Leave at least 2 * single query max points
  - Each request should try to hit single query max points. (except first probing)